### PR TITLE
Add Supabase upload when students end chat

### DIFF
--- a/app.py
+++ b/app.py
@@ -4,7 +4,12 @@ import uuid
 import time
 import gradio as gr
 
-from services.vertex_client import VERTEX_CFG, _vertex_err, _streamFromVertex
+from services.vertex_client import (
+    VERTEX_CFG,
+    _vertex_err,
+    _streamFromVertex,
+    summarize_chat_history,
+)
 from services.auth_store import _hashPw
 from services.docs import extractPdfText, createChatPdf
 from services.script_builder import buildCustomScript
@@ -12,6 +17,7 @@ from services.supabase_client import (
     SupabaseConfigurationError,
     SupabaseOperationError,
     SupabaseUserExistsError,
+    create_chat_record,
     create_classroom_record,
     create_user_record,
     create_subject_record,
@@ -1766,13 +1772,46 @@ def _sanitize_storage_segment(value):
     return text.replace("/", "-")
 
 
-def student_end_chat(history, docsState, authState, currentChatId, chatsState, selectedClass):
+def student_end_chat(
+    history,
+    docsState,
+    authState,
+    currentChatId,
+    chatsState,
+    selectedClass,
+    classrooms,
+    selectedTheme,
+    selectedSubjects,
+    studentGoal=None,
+    studentInterests=None,
+):
     chat_history = history if isinstance(history, list) else []
     docs = docsState if isinstance(docsState, dict) else {}
     chats_map = chatsState if isinstance(chatsState, dict) else {}
     active_chat_id = currentChatId if isinstance(currentChatId, str) else None
     storage_chat_id = active_chat_id or _mk_id("chat")
     pdf_path = None
+    summary_text = ""
+    classrooms_list = classrooms if isinstance(classrooms, list) else []
+    selected_theme_text = (selectedTheme or "") if isinstance(selectedTheme, str) else ""
+    if selected_theme_text:
+        selected_theme_text = selected_theme_text.strip()
+    selected_subjects = []
+    if isinstance(selectedSubjects, (list, tuple, set)):
+        for item in selectedSubjects:
+            if isinstance(item, str) and item.strip():
+                selected_subjects.append(item.strip())
+
+    goal_text = (
+        str(studentGoal).strip() if isinstance(studentGoal, str) else ""
+    )
+    interest_text = (
+        str(studentInterests).strip()
+        if isinstance(studentInterests, str)
+        else ""
+    )
+    normalized_goal_value = goal_text or "None"
+    normalized_interest_value = interest_text or "None"
 
     def _failure(message: str, warn: bool = False):
         if warn:
@@ -1790,12 +1829,15 @@ def student_end_chat(history, docsState, authState, currentChatId, chatsState, s
             chats_map,
         )
 
-    try:
-        pdf_path = createChatPdf(chat_history, docs)
-    except Exception as exc:  # pragma: no cover - depende de I/O
-        return _failure(f"Erro ao gerar PDF do chat: {exc}")
-
     student_id = (authState or {}).get("user_id")
+    if not student_id:
+        return _failure("⚠️ Não foi possível identificar o aluno logado.", warn=True)
+    is_class_chat = bool(selectedClass)
+    if not is_class_chat and not selected_theme_text:
+        return _failure(
+            "⚠️ Informe um tema para registrar o chat independente.", warn=True
+        )
+
     owner_segment = _normalize_username((authState or {}).get("username")) or "anon"
     class_segment = _sanitize_storage_segment(selectedClass) or "sem_sala"
     student_segment = _sanitize_storage_segment(student_id) or owner_segment
@@ -1803,6 +1845,58 @@ def student_end_chat(history, docsState, authState, currentChatId, chatsState, s
     filename = f"{storage_chat_id}_{_now_ts()}.pdf"
     path_parts = [segment for segment in (prefix_segment, class_segment, student_segment) if segment]
     storage_path = "/".join(path_parts + [filename])
+
+    entry = chats_map.get(storage_chat_id) if isinstance(chats_map, dict) else None
+    created_at_ts = None
+    if isinstance(entry, dict):
+        created_val = entry.get("created_at")
+        if isinstance(created_val, (int, float)):
+            created_at_ts = int(created_val)
+
+    chat_title = entry.get("title") if isinstance(entry, dict) else None
+    if not chat_title:
+        first_user_msg = next(
+            (
+                str(msg.get("content"))
+                for msg in chat_history
+                if isinstance(msg, dict)
+                and (msg.get("role") or "").lower() == "user"
+                and msg.get("content")
+            ),
+            None,
+        )
+        if first_user_msg:
+            chat_title = first_user_msg[:80]
+
+    classroom_theme = None
+    if is_class_chat:
+        for classroom in classrooms_list:
+            if isinstance(classroom, dict) and classroom.get("id") == selectedClass:
+                classroom_theme = (
+                    classroom.get("theme_name")
+                    or classroom.get("name")
+                    or classroom.get("title")
+                )
+                break
+
+    topic_value = (classroom_theme or selected_theme_text or chat_title or "").strip()
+    subject_free_text_value = "NONE" if is_class_chat else (topic_value or "Adhoc")
+    if not topic_value:
+        topic_value = "Indefinido"
+    if not subject_free_text_value:
+        subject_free_text_value = "Adhoc"
+
+    if chat_history and VERTEX_CFG and not _vertex_err:
+        try:
+            summary_text = summarize_chat_history(chat_history, VERTEX_CFG, max_phrases=2)
+        except Exception as exc:  # pragma: no cover - depende de chamadas externas
+            summary_text = ""
+            gr.Warning(f"Não foi possível gerar resumo do chat: {exc}")
+
+    try:
+        pdf_path = createChatPdf(chat_history, docs)
+    except Exception as exc:  # pragma: no cover - depende de I/O
+        return _failure(f"Erro ao gerar PDF do chat: {exc}")
 
     try:
         stored_path = upload_file_to_bucket(
@@ -1830,21 +1924,94 @@ def student_end_chat(history, docsState, authState, currentChatId, chatsState, s
             except OSError:
                 pass
 
-    entry = chats_map.get(storage_chat_id)
-    if not entry:
+    ended_ts = _now_ts()
+    started_ts = created_at_ts or ended_ts
+
+    try:
+        supabase_payload = create_chat_record(
+            SUPABASE_URL,
+            SUPABASE_SERVICE_ROLE_KEY,
+            student_id=student_id,
+            classroom_id=selectedClass,
+            started_at=started_ts,
+            ended_at=ended_ts,
+            chat_history=chat_history,
+            storage_chat_id=storage_chat_id,
+            storage_path_id=storage_chat_id,
+            storage_bucket=SUPABASE_CHAT_BUCKET,
+            storage_path=stored_path,
+            chat_title=chat_title,
+            subject_free_text=subject_free_text_value,
+            topic_source=topic_value,
+            summary=summary_text or None,
+            subject_titles=selected_subjects,
+            student_goal=goal_text,
+            student_interest=interest_text,
+            is_adhoc_chat=not is_class_chat,
+            store_messages=False,
+        )
+    except SupabaseConfigurationError:
+        return _failure(
+            "Configure SUPABASE_URL e SUPABASE_SERVICE_ROLE_KEY para registrar o chat.",
+            warn=True,
+        )
+    except SupabaseOperationError as exc:
+        return _failure(f"Falha ao registrar chat no Supabase: {exc}")
+    except Exception as exc:  # pragma: no cover - falhas inesperadas do SDK
+        return _failure(f"Erro inesperado ao registrar chat no Supabase: {exc}")
+
+    if not isinstance(entry, dict):
         entry = {
             "id": storage_chat_id,
             "owner": owner_segment,
             "role": _user_role(authState) or "aluno",
-            "created_at": _now_ts(),
+            "created_at": started_ts,
             "messages": chat_history,
         }
         chats_map[storage_chat_id] = entry
+    else:
+        entry["messages"] = chat_history
+        if not isinstance(entry.get("created_at"), (int, float)):
+            entry["created_at"] = started_ts
+
+    if chat_title and not entry.get("title"):
+        entry["title"] = chat_title
 
     entry["classroom_id"] = selectedClass
-    entry["ended_at"] = _now_ts()
+    entry["student_id"] = student_id
+    entry["started_at"] = started_ts
+    entry["ended_at"] = ended_ts
     entry["storage_bucket"] = SUPABASE_CHAT_BUCKET
     entry["storage_path"] = stored_path
+    entry["storage_path_id"] = storage_chat_id
+    entry["topic_source"] = topic_value
+    entry["subject_free_text"] = subject_free_text_value
+    if classroom_theme:
+        entry["classroom_theme"] = classroom_theme
+    if selected_subjects:
+        entry["subjects"] = selected_subjects
+    elif not entry.get("subjects"):
+        entry["subjects"] = []
+    entry["student_goal"] = normalized_goal_value
+    entry["student_interest"] = normalized_interest_value
+    if summary_text:
+        entry["summary"] = summary_text
+
+    supabase_chat = None
+    supabase_messages = None
+    if isinstance(supabase_payload, dict):
+        supabase_chat = supabase_payload.get("chat")
+        supabase_messages = supabase_payload.get("messages")
+        if not supabase_chat and supabase_payload.get("id"):
+            supabase_chat = supabase_payload
+
+    if supabase_chat:
+        entry["supabase_chat_id"] = supabase_chat.get("id")
+        entry["supabase_chat_record"] = supabase_chat
+    if supabase_messages:
+        entry["supabase_chat_messages"] = supabase_messages
+    entry["supabase_synced_at"] = ended_ts
+
     attachments = entry.setdefault("attachments", [])
     attachments.append(
         {
@@ -1854,9 +2021,11 @@ def student_end_chat(history, docsState, authState, currentChatId, chatsState, s
         }
     )
 
-    gr.Info("Chat encerrado! O PDF foi enviado para o Supabase.")
+    gr.Info("Chat encerrado! O PDF foi enviado e o registro foi salvo no Supabase.")
+    supabase_chat_id = entry.get("supabase_chat_id")
+    supabase_tag = f" supabase_id='{supabase_chat_id}'" if supabase_chat_id else ""
     print(
-        f"[CHAT] PDF enviado para Storage -> bucket='{SUPABASE_CHAT_BUCKET}' path='{stored_path}' chat='{storage_chat_id}'"
+        f"[CHAT] PDF enviado para Storage -> bucket='{SUPABASE_CHAT_BUCKET}' path='{stored_path}' chat='{storage_chat_id}'{supabase_tag}"
     )
 
     return (
@@ -1869,6 +2038,7 @@ def student_end_chat(history, docsState, authState, currentChatId, chatsState, s
         None,
         chats_map,
     )
+
 
 
 # ================================== APP / UI ==================================
@@ -2587,6 +2757,11 @@ with gr.Blocks(theme=gr.themes.Default(), fill_height=True) as demo:
             currentChatId,
             chatsState,
             studentSelectedClass,
+            classroomsState,
+            stAssunto,
+            stSubthemes,
+            stObjetivo,
+            stInteresses,
         ],
         outputs=[
             viewStudentSetup,

--- a/services/docs.py
+++ b/services/docs.py
@@ -19,8 +19,12 @@ def extractPdfText(filePath: str) -> str:
 
 
 def createChatPdf(history, docsState):
+    # use um diretório local válido
+    outDir = "./output_pdfs"
+    os.makedirs(outDir, exist_ok=True)  # garante que a pasta exista
+
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-    outPath = f"/mnt/data/chat_{timestamp}.pdf"
+    outPath = os.path.join(outDir, f"chat_{timestamp}.pdf")
 
     doc = SimpleDocTemplate(outPath, pagesize=letter, leftMargin=36,
                             rightMargin=36, topMargin=36, bottomMargin=36)


### PR DESCRIPTION
## Summary
- add a storage upload helper to the Supabase client so the app can persist generated artifacts
- wire a new "Encerrar Chat" action that exports the conversation PDF, uploads it to Supabase Storage and returns the student to the rooms page

## Testing
- python -m compileall app.py services

------
https://chatgpt.com/codex/tasks/task_e_68caaa5b89a48326af0b6ef970b00778