### PR TITLE
Restrict chat file upload controls to Vertex sessions

### DIFF
--- a/app/pages/chat.py
+++ b/app/pages/chat.py
@@ -9,7 +9,7 @@ import gradio as gr
 
 from services.docs import createChatPdf, extractPdfText
 from services.script_builder import buildCustomScript
-from services.vertex_client import VERTEX_CFG, _streamFromVertex
+from services.vertex_client import VERTEX_CFG, _streamFromVertex, _vertex_err
 
 from app.utils import _mk_id, _now_ts
 
@@ -233,10 +233,18 @@ def build_studio_page(
                     clearBtn = gr.Button("Limpar chat")
                     exportBtn = gr.Button("Exportar conversa (PDF)")
                 backToConfigBtn = gr.Button("⬅️ Voltar para customização")
+                allow_file_upload = bool(VERTEX_CFG and not _vertex_err)
+                chat_placeholder = (
+                    "Digite sua mensagem ou envie um PDF..."
+                    if allow_file_upload
+                    else "Digite sua mensagem..."
+                )
+                chat_sources = ["upload"] if allow_file_upload else []
+
                 chatInput = gr.MultimodalTextbox(
                     show_label=False,
-                    placeholder="Digite sua mensagem ou envie um PDF...",
-                    sources=["upload"],
+                    placeholder=chat_placeholder,
+                    sources=chat_sources,
                     interactive=True,
                 )
 

--- a/app/pages/student.py
+++ b/app/pages/student.py
@@ -749,10 +749,18 @@ def build_student_views(
                 with gr.Row():
                     stBackToSetup = gr.Button("⬅️ Voltar para configuração da sala")
                     stEndChat = gr.Button("Encerrar Chat", variant="stop")
+                allow_file_upload = bool(VERTEX_CFG and not _vertex_err)
+                chat_placeholder = (
+                    "Digite sua mensagem ou envie um PDF..."
+                    if allow_file_upload
+                    else "Digite sua mensagem..."
+                )
+                chat_sources = ["upload"] if allow_file_upload else []
+
                 stChatInput = gr.MultimodalTextbox(
                     show_label=False,
-                    placeholder="Digite sua mensagem ou envie um PDF...",
-                    sources=["upload"],
+                    placeholder=chat_placeholder,
+                    sources=chat_sources,
                     interactive=True,
                 )
 


### PR DESCRIPTION
## Summary
- hide the chat file upload control whenever Vertex credentials are unavailable
- adjust chat placeholders so PDF guidance only appears when uploads are supported
- apply the same conditional upload logic to the student chat view

## Testing
- python -m compileall app/pages/chat.py app/pages/student.py

------
https://chatgpt.com/codex/tasks/task_e_68d5e248393483269baf77dcfa5e9799