### PR TITLE
Render chat history previews with markdown

### DIFF
--- a/app.py
+++ b/app.py
@@ -31,6 +31,31 @@ from app.pages.student import (
 from app.pages.teacher import TeacherView, build_teacher_view
 
 
+APP_CSS = """
+.history-preview {
+    max-height: 24rem;
+    overflow-y: auto;
+    padding: 0.75rem 1rem;
+    border: 1px solid var(--block-border-color, rgba(148, 163, 184, 0.35));
+    border-radius: var(--radius-lg, 0.75rem);
+    background-color: var(--block-background-fill, rgba(255, 255, 255, 0.6));
+}
+
+.history-preview::-webkit-scrollbar {
+    width: 8px;
+}
+
+.history-preview::-webkit-scrollbar-thumb {
+    background-color: rgba(100, 116, 139, 0.45);
+    border-radius: 9999px;
+}
+
+.history-preview:hover::-webkit-scrollbar-thumb {
+    background-color: rgba(100, 116, 139, 0.75);
+}
+"""
+
+
 def _logout_cleanup():
     return (
         gr.update(visible=False),
@@ -40,7 +65,7 @@ def _logout_cleanup():
 
 
 def build_app() -> gr.Blocks:
-    with gr.Blocks(theme=gr.themes.Default(), fill_height=True) as demo:
+    with gr.Blocks(theme=gr.themes.Default(), fill_height=True, css=APP_CSS) as demo:
         auth_state = gr.State({"isAuth": False, "username": None})
         docs_state = gr.State({})
         script_state = gr.State("Você é um assistente pedagógico. Aguarde configuração do usuário.")

--- a/app/pages/admin.py
+++ b/app/pages/admin.py
@@ -185,11 +185,12 @@ def admin_history_load_chat(chat_id, history_entries, current_download_path):
             gr.Warning(result.notice)
 
     manual_value = 0
+    preview_value = result.preview_text or "ℹ️ Carregue um chat para visualizar a prévia."
 
     return (
         result.chat_id,
         gr.update(value=result.metadata_md),
-        gr.update(value=result.preview_text),
+        gr.update(value=preview_value),
         gr.update(value=result.evaluation_text),
         gr.update(value=manual_value),
         gr.update(value=result.comments_md),
@@ -951,7 +952,11 @@ def build_admin_views(
             adHistoryChat = gr.Dropdown(choices=[], label="Chat registrado", value=None)
             adHistoryLoad = gr.Button("📄 Ver detalhes")
         adHistoryMetadata = gr.Markdown("ℹ️ Selecione um chat para visualizar os detalhes.")
-        adHistoryPreview = gr.Textbox(label="Prévia do PDF", lines=12, interactive=False, value="")
+        gr.Markdown("#### Prévia do PDF")
+        adHistoryPreview = gr.Markdown(
+            "ℹ️ Carregue um chat para visualizar a prévia.",
+            elem_classes=["history-preview"],
+        )
         with gr.Row():
             adHistoryDownload = gr.DownloadButton("⬇️ Baixar PDF", visible=False, variant="secondary")
             adHistoryGenerateEval = gr.Button("🤖 Gerar avaliação automática", variant="secondary")

--- a/app/pages/student.py
+++ b/app/pages/student.py
@@ -77,7 +77,7 @@ class StudentViews:
     history_chat_dropdown: gr.Dropdown
     history_load_button: gr.Button
     history_metadata: gr.Markdown
-    history_preview: gr.Textbox
+    history_preview: gr.Markdown
     history_download_button: gr.DownloadButton
     history_evaluation: gr.Textbox
     history_comments: gr.Markdown
@@ -164,10 +164,12 @@ def student_history_load_chat(chat_id, history_entries, current_download_path):
         else:
             gr.Warning(result.notice)
 
+    preview_value = result.preview_text or "ℹ️ Carregue um chat para visualizar a prévia."
+
     return (
         result.chat_id,
         gr.update(value=result.metadata_md),
-        gr.update(value=result.preview_text),
+        gr.update(value=preview_value),
         gr.update(value=result.evaluation_text),
         gr.update(value=result.comments_md),
         result.transcript_text,
@@ -690,8 +692,10 @@ def build_student_views(
                 stHistoryChat = gr.Dropdown(choices=[], label="Chat registrado", value=None)
                 stHistoryLoad = gr.Button("📄 Ver detalhes")
             stHistoryMetadata = gr.Markdown("ℹ️ Selecione um chat para visualizar os detalhes.")
-            stHistoryPreview = gr.Textbox(
-                label="Prévia do PDF", lines=10, interactive=False, value=""
+            gr.Markdown("#### Prévia do PDF")
+            stHistoryPreview = gr.Markdown(
+                "ℹ️ Carregue um chat para visualizar a prévia.",
+                elem_classes=["history-preview"],
             )
             with gr.Row():
                 stHistoryDownload = gr.DownloadButton(

--- a/app/pages/teacher.py
+++ b/app/pages/teacher.py
@@ -128,11 +128,12 @@ def teacher_history_load_chat(
             gr.Warning(result.notice)
 
     manual_value = 0
+    preview_value = result.preview_text or "ℹ️ Carregue um chat para visualizar a prévia."
 
     return (
         result.chat_id,
         gr.update(value=result.metadata_md),
-        gr.update(value=result.preview_text),
+        gr.update(value=preview_value),
         gr.update(value=result.evaluation_text),
         gr.update(value=manual_value),
         gr.update(value=result.comments_md),
@@ -741,8 +742,10 @@ def build_teacher_view(
                 tHistoryChat = gr.Dropdown(choices=[], label="Chat registrado", value=None)
                 tHistoryLoad = gr.Button("📄 Ver detalhes")
             tHistoryMetadata = gr.Markdown("ℹ️ Selecione um chat para visualizar os detalhes.")
-            tHistoryPreview = gr.Textbox(
-                label="Prévia do PDF", lines=12, interactive=False, value=""
+            gr.Markdown("#### Prévia do PDF")
+            tHistoryPreview = gr.Markdown(
+                "ℹ️ Carregue um chat para visualizar a prévia.",
+                elem_classes=["history-preview"],
             )
             with gr.Row():
                 tHistoryDownload = gr.DownloadButton(


### PR DESCRIPTION
## Summary
- render the student, teacher, and admin chat history previews with Markdown so transcripts keep their formatting
- add shared CSS for history preview panels to allow scrolling and improve readability
- show a consistent placeholder when no transcript is available

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68d5fa62b8808326bce9bba60aa25418