### PR TITLE
Honor legacy classroom owners when checking permissions

### DIFF
--- a/app/pages/teacher.py
+++ b/app/pages/teacher.py
@@ -36,6 +36,8 @@ from app.pages.history_shared import (
     prepare_history_listing,
 )
 from app.utils import (
+    _auth_matches_classroom_owner,
+    _auth_matches_classroom_teacher,
     _auth_user_id,
     _class_member_labels,
     _get_class_by_id,
@@ -244,11 +246,9 @@ def teacher_history_prepare_download(download_path):
 def _teacher_classes(auth, classrooms: Iterable[Dict[str, Any]]):
     if _is_admin(auth):
         return list(classrooms or [])
-    me_id = _auth_user_id(auth)
     out = []
     for c in classrooms or []:
-        teachers = (c.get("members", {}) or {}).get("teachers", []) or []
-        if me_id and me_id in teachers:
+        if _auth_matches_classroom_teacher(auth, c):
             out.append(c)
     return out
 
@@ -276,30 +276,14 @@ def _render_teacher_members_md(cls_id, classrooms):
     if not c:
         return "⚠️ Selecione uma de suas salas."
     members = c.get("members", {}) or {}
-    teacher_ids = members.get("teachers", [])
-    student_ids = members.get("students", [])
-
-    teacher_labels = members.get("teacher_labels", {})
-    student_labels = members.get("student_labels", {})
-    teacher_usernames = members.get("teacher_usernames", {})
-    student_usernames = members.get("student_usernames", {})
+    teacher_ids = list(members.get("teachers", []) or [])
+    student_ids = list(members.get("students", []) or [])
 
     teachers = ", ".join(
-        (
-            f"{teacher_labels.get(uid, uid)} (u:{teacher_usernames.get(uid, uid)})"
-            if teacher_usernames.get(uid)
-            else teacher_labels.get(uid, uid)
-        )
-        for uid in teacher_ids
+        _class_member_labels(c, "teachers", include_usernames=True)
     ) or "—"
-
     students = ", ".join(
-        (
-            f"{student_labels.get(uid, uid)} (u:{student_usernames.get(uid, uid)})"
-            if student_usernames.get(uid)
-            else student_labels.get(uid, uid)
-        )
-        for uid in student_ids
+        _class_member_labels(c, "students", include_usernames=True)
     ) or "—"
 
     return (
@@ -361,12 +345,10 @@ def teacher_save_params(
     subjects,
     auth,
 ):
-    me_id = _auth_user_id(auth)
     c = _get_class_by_id(classrooms, cls_id)
     if not c:
         return classrooms, subjects, "⚠️ Sala não encontrada."
-    teachers = list((c.get("members", {}) or {}).get("teachers", []))
-    if me_id not in teachers and not _is_admin(auth):
+    if not _auth_matches_classroom_teacher(auth, c) and not _is_admin(auth):
         return classrooms, subjects, "⛔ Você não é professor desta sala."
 
     cfg = {
@@ -413,23 +395,21 @@ def _teacher_classrooms_outputs(auth, classrooms, notice=""):
 
 
 def teacher_add_teacher(cls_id, uname, classrooms, subjects, auth):
-    me_id = _auth_user_id(auth)
     uname_norm = _normalize_username(uname)
     if not cls_id or not uname_norm:
         return classrooms, subjects, "⚠️ Informe sala e username."
-    if not me_id and not _is_admin(auth):
+    if not (_auth_user_id(auth) or _teacher_username(auth) or _is_admin(auth)):
         return classrooms, subjects, "⚠️ Faça login."
 
     classroom = _get_class_by_id(classrooms, cls_id)
     if not classroom:
         return classrooms, subjects, "⚠️ Sala não encontrada."
 
-    teacher_ids = list((classroom.get("members", {}) or {}).get("teachers", []))
-    if me_id not in teacher_ids and not _is_admin(auth):
+    if not _auth_matches_classroom_teacher(auth, classroom) and not _is_admin(auth):
         return classrooms, subjects, "⛔ Você não é professor desta sala."
 
-    owner_id = classroom.get("owner_id")
-    if owner_id and me_id != owner_id and not _is_admin(auth):
+    owner_known = classroom.get("owner_id") or classroom.get("owner_login")
+    if owner_known and not _auth_matches_classroom_owner(auth, classroom) and not _is_admin(auth):
         return (
             classrooms,
             subjects,
@@ -456,7 +436,7 @@ def teacher_add_teacher(cls_id, uname, classrooms, subjects, auth):
         return classrooms, subjects, "⚠️ Usuário não encontrado."
 
     role_label = None
-    if not owner_id and me_id:
+    if not classroom.get("owner_id") and _auth_matches_classroom_owner(auth, classroom):
         role_label = "owner"
 
     try:
@@ -559,17 +539,17 @@ def teacher_refresh(auth, classrooms, subjects):
 
 
 def teacher_add_student(cls_id, uname, classrooms, subjects, auth):
-    me_id = _auth_user_id(auth)
     uname_norm = _normalize_username(uname)
     if not cls_id or not uname_norm:
         return classrooms, subjects, "⚠️ Informe sala e username."
+    if not (_auth_user_id(auth) or _teacher_username(auth) or _is_admin(auth)):
+        return classrooms, subjects, "⚠️ Faça login."
 
     classroom = _get_class_by_id(classrooms, cls_id)
     if not classroom:
         return classrooms, subjects, "⚠️ Sala não encontrada."
 
-    teachers = list((classroom.get("members", {}) or {}).get("teachers", []))
-    if me_id not in teachers and not _is_admin(auth):
+    if not _auth_matches_classroom_teacher(auth, classroom) and not _is_admin(auth):
         return classrooms, subjects, "⛔ Você não é professor desta sala."
 
     try:
@@ -614,17 +594,17 @@ def teacher_add_student(cls_id, uname, classrooms, subjects, auth):
 
 
 def teacher_rm_user(cls_id, uname, classrooms, subjects, auth):
-    me_id = _auth_user_id(auth)
     uname_norm = _normalize_username(uname)
     if not cls_id or not uname_norm:
         return classrooms, subjects, "⚠️ Informe sala e username."
+    if not (_auth_user_id(auth) or _teacher_username(auth) or _is_admin(auth)):
+        return classrooms, subjects, "⚠️ Faça login."
 
     classroom = _get_class_by_id(classrooms, cls_id)
     if not classroom:
         return classrooms, subjects, "⚠️ Sala não encontrada."
 
-    teachers = list((classroom.get("members", {}) or {}).get("teachers", []))
-    if me_id not in teachers and not _is_admin(auth):
+    if not _auth_matches_classroom_teacher(auth, classroom) and not _is_admin(auth):
         return classrooms, subjects, "⛔ Você não é professor desta sala."
 
     try:
@@ -672,14 +652,12 @@ def teacher_subjects_refresh(auth, classrooms, selected_id, subjects_by_class):
 
 
 def teacher_add_subject(auth, selected_id, subj, subjects_by_class, classrooms):
-    me_id = _auth_user_id(auth)
     if not selected_id:
         return classrooms, subjects_by_class, gr.update(), gr.update(), "ℹ️ Selecione uma sala."
     classroom = _get_class_by_id(classrooms, selected_id)
     if not classroom:
         return classrooms, subjects_by_class, gr.update(), gr.update(), "⚠️ Sala não encontrada."
-    teachers = list((classroom.get("members", {}) or {}).get("teachers", []))
-    if me_id not in teachers and not _is_admin(auth):
+    if not _auth_matches_classroom_teacher(auth, classroom) and not _is_admin(auth):
         return classrooms, subjects_by_class, gr.update(), gr.update(), "⛔ Você não é professor desta sala."
     subj_name = (subj or "").strip()
     if not subj_name:
@@ -720,9 +698,7 @@ def teacher_apply_active(auth, selected_id, actives, subjects_by_class, classroo
     classroom = _get_class_by_id(classrooms, selected_id)
     if not classroom:
         return classrooms, subjects_by_class, "⚠️ Sala não encontrada."
-    me_id = _auth_user_id(auth)
-    teachers = list((classroom.get("members", {}) or {}).get("teachers", []))
-    if me_id not in teachers and not _is_admin(auth):
+    if not _auth_matches_classroom_teacher(auth, classroom) and not _is_admin(auth):
         return classrooms, subjects_by_class, "⛔ Você não é professor desta sala."
 
     current = list(subjects_by_class.get(selected_id, []))

--- a/app/utils.py
+++ b/app/utils.py
@@ -5,6 +5,9 @@ import uuid
 from typing import Any, Dict, Iterable, List, Optional
 
 
+LEGACY_OWNER_SENTINEL_PREFIX = "legacy-owner::"
+
+
 def _now_ts() -> int:
     """Return current epoch timestamp in seconds."""
     return int(time.time())
@@ -18,6 +21,15 @@ def _mk_id(prefix: str = "id") -> str:
 def _normalize_username(value: Optional[str]) -> str:
     """Normalize usernames to ease comparisons inside Supabase payloads."""
     return (value or "").strip().lower()
+
+
+def _legacy_owner_sentinel(login: Optional[str]) -> Optional[str]:
+    """Return deterministic sentinel identifier for legacy owner logins."""
+
+    normalized = _normalize_username(login)
+    if not normalized:
+        return None
+    return f"{LEGACY_OWNER_SENTINEL_PREFIX}{normalized}"
 
 
 def _user_role(auth: Optional[Dict[str, Any]]) -> str:
@@ -52,6 +64,14 @@ def _teacher_username(auth: Optional[Dict[str, Any]]) -> str:
 
 def _student_username(auth: Optional[Dict[str, Any]]) -> str:
     return _normalize_username((auth or {}).get("username"))
+
+
+def _auth_login(auth: Optional[Dict[str, Any]]) -> str:
+    """Return normalized login/username for the current auth payload."""
+
+    if not isinstance(auth, dict):
+        return ""
+    return _normalize_username(auth.get("username") or auth.get("login"))
 
 
 def _get_class_by_id(classrooms: Iterable[Dict[str, Any]], cls_id: Optional[str]):
@@ -109,8 +129,15 @@ def _class_member_labels(
         normalized_username = _normalize_username(username_label) if username_label else ""
         display_username = username_label or normalized_username
 
+        is_legacy_owner = identifier.startswith(LEGACY_OWNER_SENTINEL_PREFIX)
+        legacy_hint = ""
+        if is_legacy_owner:
+            legacy_hint = identifier[len(LEGACY_OWNER_SENTINEL_PREFIX) :]
+            if not base_label:
+                base_label = display_username or legacy_hint or identifier
+
         if username_only:
-            formatted = display_username or identifier
+            formatted = display_username or base_label or identifier
         elif include_usernames:
             compare_label = base_label.lower() if base_label else ""
             compare_username = (display_username or "").lower()
@@ -123,9 +150,78 @@ def _class_member_labels(
         else:
             formatted = base_label or display_username or identifier
 
+        if is_legacy_owner and formatted:
+            formatted = f"{formatted} (responsável)"
+
         if formatted:
             sort_key = (base_label or display_username or identifier).lower()
             results.append((sort_key, formatted))
 
     results.sort(key=lambda item: item[0])
     return [label for _, label in results]
+
+
+def _auth_matches_classroom_teacher(
+    auth: Optional[Dict[str, Any]], classroom: Optional[Dict[str, Any]]
+) -> bool:
+    """Return True if auth matches one of the classroom teachers."""
+
+    if not isinstance(classroom, dict):
+        return False
+
+    members = (classroom.get("members") or {})
+    teacher_ids = [str(uid) for uid in members.get("teachers", []) if uid]
+    if not teacher_ids:
+        teacher_ids = []
+
+    user_id = _auth_user_id(auth)
+    if user_id:
+        user_id = str(user_id)
+    if user_id and user_id in teacher_ids:
+        return True
+
+    login = _auth_login(auth)
+    if not login:
+        return False
+
+    teacher_usernames = members.get("teacher_usernames") or {}
+    for identifier in teacher_ids:
+        username = teacher_usernames.get(identifier)
+        if username and _normalize_username(username) == login:
+            return True
+    return False
+
+
+def _auth_matches_classroom_owner(
+    auth: Optional[Dict[str, Any]], classroom: Optional[Dict[str, Any]]
+) -> bool:
+    """Return True if auth represents the classroom owner."""
+
+    if not isinstance(classroom, dict):
+        return False
+
+    owner_id = classroom.get("owner_id")
+    user_id = _auth_user_id(auth)
+    if user_id:
+        user_id = str(user_id)
+    if owner_id:
+        return bool(user_id) and str(owner_id) == user_id
+
+    login = _auth_login(auth)
+    if not login:
+        return False
+
+    owner_login = _normalize_username(
+        classroom.get("owner_login") or classroom.get("owner_username")
+    )
+    if owner_login and login == owner_login:
+        return True
+
+    sentinel = _legacy_owner_sentinel(owner_login or login)
+    if sentinel:
+        members = (classroom.get("members") or {})
+        teacher_usernames = members.get("teacher_usernames") or {}
+        if _normalize_username(teacher_usernames.get(sentinel)) == login:
+            return True
+
+    return False


### PR DESCRIPTION
## Summary
- persist Supabase owner_login information during domain sync and surface legacy owners via a deterministic sentinel entry
- add reusable helpers that compare classroom ownership and membership using UUIDs first while falling back to normalized logins
- refactor teacher/admin membership guards and member rendering to rely on the new helpers so legacy classrooms remain manageable

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68dbce859b48832696135fd7a3126d89